### PR TITLE
Commit lockfile and use it for rubocop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .bundle
-Gemfile.lock
 coverage
 .rvmrc
 tmp

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,74 @@
+PATH
+  remote: .
+  specs:
+    representor (0.0.1)
+      rake
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.0.0)
+    astrolabe (1.3.0)
+      parser (>= 2.2.0.pre.3, < 3.0)
+    byebug (3.5.1)
+      columnize (~> 0.8)
+      debugger-linecache (~> 1.2)
+      slop (~> 3.6)
+    codeclimate-test-reporter (0.4.5)
+      simplecov (>= 0.7.1, < 1.0.0)
+    columnize (0.9.0)
+    debugger (1.6.8)
+      columnize (>= 0.3.1)
+      debugger-linecache (~> 1.2.0)
+      debugger-ruby_core_source (~> 1.3.5)
+    debugger-linecache (1.2.0)
+    debugger-ruby_core_source (1.3.7)
+    diff-lcs (1.2.5)
+    docile (1.1.5)
+    multi_json (1.10.1)
+    parser (2.2.0.2)
+      ast (>= 1.1, < 3.0)
+    powerpack (0.0.9)
+    rainbow (2.0.0)
+    rake (10.4.2)
+    redcarpet (3.2.2)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
+    rspec-support (3.1.2)
+    rubocop (0.27.0)
+      astrolabe (~> 1.3)
+      parser (>= 2.2.0.pre.6, < 3.0)
+      powerpack (~> 0.0.6)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.4)
+    ruby-progressbar (1.7.1)
+    simplecov (0.9.1)
+      docile (~> 1.1.0)
+      multi_json (~> 1.0)
+      simplecov-html (~> 0.8.0)
+    simplecov-html (0.8.0)
+    slop (3.6.0)
+    yard (0.8.7.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  byebug
+  codeclimate-test-reporter
+  debugger
+  redcarpet (~> 3.2)
+  representor!
+  rspec (~> 3.1)
+  rubocop (~> 0.27)
+  simplecov (~> 0.9)
+  yard (~> 0.8.7)

--- a/tasks/spec.rake
+++ b/tasks/spec.rake
@@ -1,3 +1,5 @@
+require 'bundler/setup'
+
 desc 'Runs all the specs'
 
 begin


### PR DESCRIPTION
I noticed the following was failing, https://github.com/the-hypermedia-project/representor-ruby/pull/5 this is due to changes in Rubocop. We have two problems currently:
- The Gemfile.lock wasn't committed, so everyone can have different versions of utilities
- Running Rubocop from rake didn't actually use the bundler version, but instead the latest system version of rubocop

This will conflict with #5, so @fosrias please let me know if all the PR's are okay and I'll sort conflicts out once one is merged.
